### PR TITLE
fix(cis_6.3.4.3): change audit log group owner from root to adm

### DIFF
--- a/section_6/cis_6.3.4/cis_6.3.4.3.yml
+++ b/section_6/cis_6.3.4/cis_6.3.4.3.yml
@@ -8,7 +8,7 @@ command:
     exec: for file in `grep ^log_file /etc/audit/auditd.conf | awk '{ print $NF }'`; do stat -Lc "%n_%U" $file; done
     exit-status: 0
     stdout:
-    - '/.*_root$/'
+    - '/.*_adm$/'
     meta:
       server: 2
       workstation: 2


### PR DESCRIPTION
**Overall Review of Changes:**
This fix addresses the issues outlined in the linked issue below. During post-remediation audit this check was failing due to `auditd` setting the group owner of the audit log file back to the default of `adm`.

**Issue Fixes:**
Related ansible-lockdown/DEBIAN12-CIS#59
May want to merge after ansible-lockdown/DEBIAN12-CIS#60

**How has this been tested?:**
This check now passes with the Debian default `adm` config in `auditd.conf` which also complies with CIS benchmark, and also in combination with the change in ansible-lockdown/DEBIAN12-CIS#60