### PR TITLE
fix 6.1.3.6 && 6.1.3.7 fix deb12cis_remote_log_host

### DIFF
--- a/section_6/cis_6.1.3.x/cis_6.1.3.6.yml
+++ b/section_6/cis_6.1.3.x/cis_6.1.3.6.yml
@@ -2,7 +2,7 @@
 
 {{ if .Vars.deb12cis_level_1 }}
   {{ if .Vars.deb12cis_rule_6_1_3_6 }}
-    {{ if not .Vars.deb12cis_remote_log_server }}
+    {{ if not .Vars.deb12cis_remote_log_host }}
 command:
   remote_syslog:
     title: 6.1.3.6 | Ensure rsyslog is configured to send logs to a remote host

--- a/section_6/cis_6.1.3.x/cis_6.1.3.7.yml
+++ b/section_6/cis_6.1.3.x/cis_6.1.3.7.yml
@@ -3,7 +3,7 @@
 
 {{ if .Vars.deb12cis_level_1 }}
   {{ if .Vars.deb12cis_rule_6_1_3_7 }}
-    {{ if not .Vars.deb12cis_remote_log_server }}
+    {{ if not .Vars.deb12cis_remote_log_host }}
 command:
   local_syslog_module:
     title: 6.1.3.7 | Ensure rsyslog is not configured to recieve logs from a remote client | module


### PR DESCRIPTION
deb12cis_remote_log_server don't exist, it's deb12cis_remote_log_host

Error: could not read json data in /opt/DEBIAN12-CIS-Audit/section_6/cis_6.1.3.x/cis_6.1.3.6.yml:
template: test:5:19: executing "test" at <.Vars.deb12cis_remote_log_server>: map has no entry for key "deb12cis_remote_log_server"


