### PR TITLE
fix 6.1.3.8 : use deb12 not suse15

### DIFF
--- a/section_6/cis_6.1.3.x/cis_6.1.3.8.yml
+++ b/section_6/cis_6.1.3.x/cis_6.1.3.8.yml
@@ -1,8 +1,8 @@
 
 ---
 
-{{ if .Vars.suse15cis_level_1 }}
-  {{ if .Vars.suse15cis_rule_6_1_3_8 }}
+{{ if .Vars.deb12cis_level_1 }}
+  {{ if .Vars.deb12cis_rule_6_1_3_8 }}
 command:
   rsyslog_logrotate:
     title: 6.1.3.8 | Ensure rsyslog logrotate is configured | Manual Check


### PR DESCRIPTION
seem to be  an original copy paste from suse15

Error: could not read json data in /opt/DEBIAN12-CIS-Audit/section_6/cis_6.1.3.x/cis_6.1.3.8.yml: template: test:4:11: executing "test" at <.Vars.suse15cis_level_1>: map has no entry for key "suse15cis_level_1"

