### PR TITLE
fix cis_2.3.3.1 : use chrony source.d/*.sources

### DIFF
--- a/section_2/cis_2.3/cis_2.3.3.1.yml
+++ b/section_2/cis_2.3/cis_2.3.3.1.yml
@@ -6,7 +6,7 @@
 file:
   chrony_pool:
     title: 2.3.3.1 | Ensure chrony is configured with authorized timeserver | timeserver pool
-    path: /etc/chrony/sources.d/pool.source
+    path: /etc/chrony/sources.d/pool.sources
     exists: true
     contents:
     {{- range .Vars.deb12cis_time_pool }}
@@ -26,7 +26,7 @@ file:
       - AU-12
   chrony_timeservers:
     title: 2.3.3.1 | Ensure chrony is configured with authorized timeserver | timeserver servers
-    path: /etc/chrony/sources.d/server.source
+    path: /etc/chrony/sources.d/server.sources
     exists: true
     contents:
     {{- range .Vars.deb12cis_time_servers }}


### PR DESCRIPTION
The valid files are *.sources  not *.source


