### PR TITLE
fix 1.2.2.1: tail apt-update + force LC_ALL=C

### DIFF
--- a/section_1/cis_1.2.x/cis_1.2.2.1.yml
+++ b/section_1/cis_1.2.x/cis_1.2.2.1.yml
@@ -8,9 +8,10 @@ command:
     title: 1.2.2.1 | Ensure updates, patches, and additional security software are installed
     exit-status: 0
     timeout: {{ .Vars.timeout_ms }}
-    exec: apt update
+    exec: LC_ALL=C apt update | tail -1
     stdout:
-    - 'All packages are up to date'
+    - '!/^[1-9]{0,4}$ packages can be upgraded/'
+    - '/^All packages are up to date/'
     meta:
       server: 1
       workstation: 1


### PR DESCRIPTION
apt-update return multiple lines, we need to tail on the last line.

Also force LC_ALL=C, because non english server are returning localized message without it.



