### PR TITLE
fix cis_7.2.9 : Ensure all users' home directories exist

### DIFF
--- a/section_7/cis_7.2/cis_7.2.9.yml
+++ b/section_7/cis_7.2/cis_7.2.9.yml
@@ -23,11 +23,10 @@ command:
       NIST800-53R5: NA
   home_dirs_owned:
     title: 7.2.9 | Ensure all users' home directories exist | owned
-    exec: getent passwd {1000..60000} |  awk -F':' '{ print $1  " "  $6 }' | while read user dir; do if [ $user != 'ftpd' ]; then owner=$(stat -L -c "%U" "$dir"); if [ "$owner" != "$user" ]; then echo "home dir for $user owned by $owner"; fi; fi; done
-    exit-status: 0
-    timeout: {{ .Vars.timeout_ms }}
+    exec: "getent passwd | awk -F: '$3 >= 1000 && $3 <= 60000 && $1 != \"ftpd\" {print $1, $6}' | while read user dir; do [ -e \"$dir\" ] && owner=$(stat -L -c \"%U\" \"$dir\" 2>/dev/null) && [ \"$owner\" != \"$user\" ] && echo \"home dir for $user owned by $owner\"; done"
+    exit-status: 1
     stdout:
-    - '!/./'
+    - '!/.*/'
     meta:
       server: 1
       workstation: 1
@@ -40,9 +39,8 @@ command:
       NIST800-53R5: NA
   home_dirs_restrict:
     title: 7.2.9 | Ensure all users' home directories exist | permissions
-    exec: for i in $(getent passwd {1000..60000} | awk '{split($0,a,":");print a[6]}'); do stat -c "%a %n" $i ; done
+    exec: "getent passwd | awk -F: '$3 >= 1000 && $3 <= 60000 {print $6}' | xargs -P 4 -I {} stat -c \"%a %n\" {}"
     exit-status: 0
-    timeout: {{ .Vars.timeout_ms }}
     stdout:
     - '/^7(0|5)0\s/'
     meta:


### PR DESCRIPTION
current the check seem to fail because of timeout.
avoid to call getent password 60000x which is super slow (30~40s with local accounts)