### PR TITLE
QA: Fix run_audit.sh OS detection and LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 Mindpoint Group - A Tyto Athene Company / Ansible Lockdown
+Copyright (c) 2026 MindPoint Group - A Tyto Athene Company / Ansible Lockdown
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/run_audit.sh
+++ b/run_audit.sh
@@ -87,10 +87,19 @@ fi
 
 # Discover OS version aligning with audit
 # Define os_vendor variable
-if [ "$(uname -a | grep -c amzn)" -ge 1 ]; then
-    os_vendor="AMAZON"
-elif [ "$(grep -Ec "rhel|oracle" /etc/os-release)" != 0 ]; then
-  os_vendor="RHEL"
+# Use /etc/os-release as primary source (works in containers where uname/hostnamectl may fail)
+if [ -f /etc/os-release ]; then
+  os_id="$(grep -w "^ID=" /etc/os-release | cut -d= -f2 | tr -d '"' | awk '{print tolower($0)}')"
+  case "$os_id" in
+    amzn) os_vendor="AMAZON" ;;
+    rhel|ol|oracle|rocky|almalinux|centos) os_vendor="RHEL" ;;
+    debian) os_vendor="DEBIAN" ;;
+    ubuntu) os_vendor="UBUNTU" ;;
+    sles|opensuse*) os_vendor="SUSE" ;;
+    *) os_vendor="$(echo "$os_id" | awk '{print toupper($0)}')" ;;
+  esac
+elif [ "$(uname -a | grep -c amzn)" -ge 1 ]; then
+  os_vendor="AMAZON"
 else
   os_vendor="$(hostnamectl | grep Oper | cut -d : -f2 | awk '{print toupper($1)}')"
   if [ "${os_vendor}" = "OPENSUSE" ]; then


### PR DESCRIPTION
Please ensure that you have understood contributing guide
Ensure all commits are signed-by and gpg signed

**Overall Review of Changes:**
QA fixes for the Debian 12 CIS audit repo from the May 2026 QA pass.

**Issue Fixes:**
N/A

**Enhancements:**
- Fix run_audit.sh OS detection via /etc/os-release for container support (uname fails in containers)
- Fix LICENSE company name casing (Mindpoint -> MindPoint)

**How has this been tested?:**
Molecule converge with setup_audit: true, run_audit: true on geerlingguy/docker-debian12-ansible container. Pre-audit: 109 failures, post-audit: 48 failures (56% improvement).