### PR TITLE
Fix double-pipe artifacts in goss audit titles

### DIFF
--- a/section_1/cis_1.2.x/cis_1.2.1.2.yml
+++ b/section_1/cis_1.2.x/cis_1.2.1.2.yml
@@ -5,7 +5,7 @@
     {{ if .Vars.deb12cis_rule_1_2_1_2 }}
 command:
   repos_configured:
-    title: 1.2.1.2 | Ensure package manager repositories are configured | | Manual
+    title: 1.2.1.2 | Ensure package manager repositories are configured | Manual
     exit-status: 0
     exec: echo "MANUAL - Ensure repos match site policy"
     stdout:

--- a/section_1/cis_1.5.x/cis_1.5.1.yml
+++ b/section_1/cis_1.5.x/cis_1.5.1.yml
@@ -4,7 +4,7 @@
   {{ if .Vars.deb12cis_rule_1_5_1 }}
 kernel-param:
   address_space_random:
-    title: 1.5.1 | Ensure address space layout randomization is enabled | | running
+    title: 1.5.1 | Ensure address space layout randomization is enabled | running
     name: kernel.randomize_va_space
     value: '2'
     meta:
@@ -20,7 +20,7 @@ kernel-param:
       NIST800-53R5: CM-6
 command:
   aslr_enabled_2:
-    title: 1.5.1 | Ensure address space layout randomization is enabled | | conf
+    title: 1.5.1 | Ensure address space layout randomization is enabled | conf
     exit-status: 0
     exec: 'grep "kernel\.randomize_va_space" /etc/sysctl.conf /etc/sysctl.d/*'
     stdout:

--- a/section_1/cis_1.5.x/cis_1.5.2.yml
+++ b/section_1/cis_1.5.x/cis_1.5.2.yml
@@ -20,7 +20,7 @@ kernel-param:
       NIST800-53R5: CM-6
 command:
   ptrace_restricted_2:
-    title: 1.5.2 | Ensure ptrace_scope is restricted | | conf
+    title: 1.5.2 | Ensure ptrace_scope is restricted | conf
     exit-status: 0
     exec: 'grep "kernel\.yama\.ptrace_scope" /etc/sysctl.conf /etc/sysctl.d/*'
     stdout:

--- a/section_2/cis_2.1/cis_2.1.12.yml
+++ b/section_2/cis_2.1/cis_2.1.12.yml
@@ -26,7 +26,7 @@ package:
       {{ if .Vars.deb12cis_rpc_mask }}
 file:
   rpcbind_service_masked:
-    title: 2.1.12 | Ensure rpcbind services are not in use | | masked
+    title: 2.1.12 | Ensure rpcbind services are not in use | masked
     path: /etc/systemd/system/rpcbind.service
     exists: true
     filetype: symlink
@@ -45,7 +45,7 @@ file:
       - CM-6
       - CM-7
   rpcbind_socket_masked:
-    title: 2.1.12 | Ensure rpcbind services are not in use | | masked
+    title: 2.1.12 | Ensure rpcbind services are not in use | masked
     path: /etc/systemd/system/rpcbind.socket
     exists: true
     filetype: symlink

--- a/section_2/cis_2.1/cis_2.1.14.yml
+++ b/section_2/cis_2.1/cis_2.1.14.yml
@@ -26,7 +26,7 @@ package:
       {{ if .Vars.deb12cis_samba_mask }}
 file:
   samba_service_masked:
-    title: 2.1.14 | Ensure samba file server services are not in use | | masked
+    title: 2.1.14 | Ensure samba file server services are not in use | masked
     path: /etc/systemd/system/smb.service
     exists: true
     filetype: symlink

--- a/section_2/cis_2.1/cis_2.1.15.yml
+++ b/section_2/cis_2.1/cis_2.1.15.yml
@@ -6,7 +6,7 @@
       {{ if not .Vars.deb12cis_snmp_mask }}
 package:
   snmp_pkg:
-    title: 2.1.14 | Ensure samba file server services are not in use | | pkg removed
+    title: 2.1.14 | Ensure samba file server services are not in use | pkg removed
     name: snmpd
     installed: false
     meta:
@@ -25,7 +25,7 @@ package:
       {{ if .Vars.deb12cis_snmp_mask }}
 file:
   snmp_service_masked:
-    title: 2.1.14 | Ensure samba file server services are not in use | | masked
+    title: 2.1.14 | Ensure samba file server services are not in use | masked
     path: /etc/systemd/system/snmpd.service
     exists: true
     filetype: symlink

--- a/section_2/cis_2.1/cis_2.1.5.yml
+++ b/section_2/cis_2.1/cis_2.1.5.yml
@@ -6,7 +6,7 @@
       {{ if not .Vars.deb12cis_dnsmasq_mask }}
 package:
   dnsmasq_pkg:
-    title: 2.1.5 | Ensure dnsmasq services are not in use | | pkg removed
+    title: 2.1.5 | Ensure dnsmasq services are not in use | pkg removed
     name: dnsmasq
     installed: false
     meta:
@@ -25,7 +25,7 @@ package:
       {{ if .Vars.deb12cis_dnsmasq_mask }}
 file:
   dnsmasq_service_masked:
-    title: 2.1.5 | Ensure dnsmasq services are not in use | | masked
+    title: 2.1.5 | Ensure dnsmasq services are not in use | masked
     path: /etc/systemd/system/dnsmasq.service
     exists: true
     filetype: symlink

--- a/section_2/cis_2.1/cis_2.1.7.yml
+++ b/section_2/cis_2.1/cis_2.1.7.yml
@@ -6,7 +6,7 @@
       {{ if not .Vars.deb12cis_ldap_mask }}
 package:
   ldap_pkg:
-    title: 2.1.6 | Ensure ftp server services are not in use | | pkg removed
+    title: 2.1.6 | Ensure ftp server services are not in use | pkg removed
     name: slapd
     installed: false
     meta:
@@ -25,7 +25,7 @@ package:
       {{ if .Vars.deb12cis_ldap_mask }}
 file:
   ldap_service_masked:
-    title: 2.1.6 | Ensure ftp server services are not in use | | masked
+    title: 2.1.6 | Ensure ftp server services are not in use | masked
     path: /etc/systemd/system/slapd.service
     exists: true
     filetype: symlink

--- a/section_2/cis_2.3/cis_2.3.1.1.yml
+++ b/section_2/cis_2.3/cis_2.3.1.1.yml
@@ -20,7 +20,7 @@ package:
       - AU-12
   {{ if eq .Vars.deb12cis_time_sync_tool "systemd-timesyncd" }}
   ntp:
-    title: 2.3.1.1 | Ensure a single time synchronization daemon is in use | | ntp service
+    title: 2.3.1.1 | Ensure a single time synchronization daemon is in use | ntp service
     installed: false
     meta:
       server: 1
@@ -35,7 +35,7 @@ package:
       - AU-3
       - AU-12
   chrony:
-    title: 2.3.1.1 | Ensure a single time synchronization daemon is in use | | chrony service
+    title: 2.3.1.1 | Ensure a single time synchronization daemon is in use | chrony service
     installed: false
     meta:
       server: 1
@@ -53,7 +53,7 @@ package:
   {{ if ne .Vars.deb12cis_time_sync_tool "systemd-timesyncd" }}
 file:
   timesync_masked:
-    title: 2.3.1.1 | Ensure a single time synchronization daemon is in use | | systemd-timesyncd masked
+    title: 2.3.1.1 | Ensure a single time synchronization daemon is in use | systemd-timesyncd masked
     path: /etc/systemd/system/systemd-timesyncd.service
     filetype: symlink
     linked-to: /dev/null

--- a/section_3/cis_3.1/cis_3.1.3.yml
+++ b/section_3/cis_3.1/cis_3.1.3.yml
@@ -25,7 +25,7 @@ package:
       {{ if .Vars.deb12cis_bluetooth_mask }}
 file:
   bluetooth_service_masked:
-    title: 3.1.3 | Ensure bluetooth services are not in use | | masked
+    title: 3.1.3 | Ensure bluetooth services are not in use | masked
     path: /etc/systemd/system/bluetooth.service
     exists: true
     filetype: symlink

--- a/section_3/cis_3.3/cis_3.3.1.yml
+++ b/section_3/cis_3.3/cis_3.3.1.yml
@@ -4,7 +4,7 @@
     {{ if .Vars.deb12cis_rule_3_3_1 }}
 kernel-param:
   net.ipv4.ip_forward:
-    title: 3.3.1 | Ensure ip forwarding is disabled | | ipv4 live
+    title: 3.3.1 | Ensure ip forwarding is disabled | ipv4 live
     value: '0'
     name: net.ipv4.ip_forward
     meta:
@@ -24,7 +24,7 @@ kernel-param:
       - IA-5
   {{ if .Vars.deb12cis_ipv6_required }}
   net.ipv6.conf.all.forwarding:
-    title: 3.3.1 | Ensure ip forwarding is disabled | | ipv6 live
+    title: 3.3.1 | Ensure ip forwarding is disabled | ipv6 live
     value: '0'
     name: net.ipv6.conf.all.forwarding
     meta:
@@ -44,7 +44,7 @@ kernel-param:
       - IA-5
 command:
   ip4_forward_conf:
-    title: 3.3.1 | Ensure ip forwarding is disabled | | ipv4 conf
+    title: 3.3.1 | Ensure ip forwarding is disabled | ipv4 conf
     exec: grep net.ipv4.ip_forward /etc/sysctl.conf /etc/sysctl.d/*.conf /run/sysctl.d/*.conf /usr/local/lib/sysctl.d/*.conf /usr/lib/sysctl.d/*.conf /lib/sysctl.d/*.conf
     exit-status:
       or:
@@ -69,7 +69,7 @@ command:
       - CM-7
       - IA-5
   ip6_forward_conf:
-    title: 3.3.1 | Ensure ip forwarding is disabled | | ipv6 conf
+    title: 3.3.1 | Ensure ip forwarding is disabled | ipv6 conf
     exec: grep net.ipv6.conf.all.forwarding /etc/sysctl.conf /etc/sysctl.d/*.conf /run/sysctl.d/*.conf /usr/local/lib/sysctl.d/*.conf /usr/lib/sysctl.d/*.conf /lib/sysctl.d/*.conf
     exit-status:
       or:

--- a/section_3/cis_3.3/cis_3.3.10.yml
+++ b/section_3/cis_3.3/cis_3.3.10.yml
@@ -24,7 +24,7 @@ kernel-param:
       - IA-5
 command:
   ipv4_tcp_syn_cookies:
-    title: 3.3.10 | Ensure tcp syn cookies is enabled | | live ipv4
+    title: 3.3.10 | Ensure tcp syn cookies is enabled | live ipv4
     exec: grep net.ipv4.tcp_syncookies /etc/sysctl.conf /etc/sysctl.d/*.conf /run/sysctl.d/*.conf /usr/local/lib/sysctl.d/*.conf /usr/lib/sysctl.d/*.conf /lib/sysctl.d/*.conf
     exit-status:
       or:

--- a/section_3/cis_3.3/cis_3.3.11.yml
+++ b/section_3/cis_3.3/cis_3.3.11.yml
@@ -44,7 +44,7 @@ kernel-param:
       - IA-5
 command:
   ipv6_all_accept_ra:
-    title: 3.3.11 | Ensure ipv6 router advertisements are not accepted | | live ipv6 all
+    title: 3.3.11 | Ensure ipv6 router advertisements are not accepted | live ipv6 all
     exec: grep net.ipv6.conf.all.accept_ra /etc/sysctl.conf /etc/sysctl.d/*.conf /run/sysctl.d/*.conf /usr/local/lib/sysctl.d/*.conf /usr/lib/sysctl.d/*.conf /lib/sysctl.d/*.conf
     exit-status:
       or:
@@ -69,7 +69,7 @@ command:
       - CM-7
       - IA-5
   ipv6_default_accept_ra:
-    title: 3.3.11 | Ensure ipv6 router advertisements are not accepted | | live ipv6 default
+    title: 3.3.11 | Ensure ipv6 router advertisements are not accepted | live ipv6 default
     exec: grep net.ipv6.conf.default.accept_ra /etc/sysctl.conf /etc/sysctl.d/*.conf /run/sysctl.d/*.conf /usr/local/lib/sysctl.d/*.conf /usr/lib/sysctl.d/*.conf /lib/sysctl.d/*.conf
     exit-status:
       or:

--- a/section_3/cis_3.3/cis_3.3.3.yml
+++ b/section_3/cis_3.3/cis_3.3.3.yml
@@ -24,7 +24,7 @@ kernel-param:
       - IA-5
 command:
   ipv4_ignore_bogus:
-    title: 3.3.3 | Ensure bogus icmp responses are ignored | | live ipv4 all
+    title: 3.3.3 | Ensure bogus icmp responses are ignored | live ipv4 all
     exec: grep net.ipv4.icmp_ignore_bogus_error_responses /etc/sysctl.conf /etc/sysctl.d/*.conf /run/sysctl.d/*.conf /usr/local/lib/sysctl.d/*.conf /usr/lib/sysctl.d/*.conf /lib/sysctl.d/*.conf
     exit-status:
       or:

--- a/section_3/cis_3.3/cis_3.3.4.yml
+++ b/section_3/cis_3.3/cis_3.3.4.yml
@@ -24,7 +24,7 @@ kernel-param:
       - IA-5
 command:
   ipv4_echo_ignore_broadcasts:
-    title: 3.3.4 | Ensure broadcast icmp requests are ignored | | live ipv4 all
+    title: 3.3.4 | Ensure broadcast icmp requests are ignored | live ipv4 all
     exec: grep net.ipv4.icmp_echo_ignore_broadcasts /etc/sysctl.conf /etc/sysctl.d/*.conf /run/sysctl.d/*.conf /usr/local/lib/sysctl.d/*.conf /usr/lib/sysctl.d/*.conf /lib/sysctl.d/*.conf
     exit-status:
       or:

--- a/section_3/cis_3.3/cis_3.3.5.yml
+++ b/section_3/cis_3.3/cis_3.3.5.yml
@@ -81,7 +81,7 @@ kernel-param:
       - IA-5
 command:
   ipv4_all_accept_redirects:
-    title: 3.3.5 | Ensure icmp redirects are not accepted | | live ipv4 all
+    title: 3.3.5 | Ensure icmp redirects are not accepted | live ipv4 all
     exec: grep net.ipv4.conf.all.accept_redirects /etc/sysctl.conf /etc/sysctl.d/*.conf /run/sysctl.d/*.conf /usr/local/lib/sysctl.d/*.conf /usr/lib/sysctl.d/*.conf /lib/sysctl.d/*.conf
     exit-status:
       or:
@@ -106,7 +106,7 @@ command:
       - CM-7
       - IA-5
   ipv4_default_accept_redirects:
-    title: 3.3.5 | Ensure icmp redirects are not accepted | | live ipv4 default
+    title: 3.3.5 | Ensure icmp redirects are not accepted | live ipv4 default
     exec: grep net.ipv4.conf.default.accept_redirects /etc/sysctl.conf /etc/sysctl.d/*.conf /run/sysctl.d/*.conf /usr/local/lib/sysctl.d/*.conf /usr/lib/sysctl.d/*.conf /lib/sysctl.d/*.conf
     exit-status:
       or:
@@ -131,7 +131,7 @@ command:
       - CM-7
       - IA-5
   ipv6_all_accept_redirects:
-    title: 3.3.5 | Ensure icmp redirects are not accepted | | live ipv6 all
+    title: 3.3.5 | Ensure icmp redirects are not accepted | live ipv6 all
     exec: grep net.ipv6.conf.all.accept_redirects /etc/sysctl.conf /etc/sysctl.d/*.conf /run/sysctl.d/*.conf /usr/local/lib/sysctl.d/*.conf /usr/lib/sysctl.d/*.conf /lib/sysctl.d/*.conf
     exit-status:
       or:
@@ -156,7 +156,7 @@ command:
       - CM-7
       - IA-5
   ipv6_default_accept_redirects:
-    title: 3.3.5 | Ensure icmp redirects are not accepted | | live ipv6 default
+    title: 3.3.5 | Ensure icmp redirects are not accepted | live ipv6 default
     exec: grep net.ipv6.conf.default.accept_redirects /etc/sysctl.conf /etc/sysctl.d/*.conf /run/sysctl.d/*.conf /usr/local/lib/sysctl.d/*.conf /usr/lib/sysctl.d/*.conf /lib/sysctl.d/*.conf
     exit-status:
       or:

--- a/section_3/cis_3.3/cis_3.3.6.yml
+++ b/section_3/cis_3.3/cis_3.3.6.yml
@@ -43,7 +43,7 @@ kernel-param:
       - IA-5
 command:
   ipv4_all_secure_redirects:
-    title: 3.3.6 | Ensure secure icmp redirects are not accepted | | live ipv4 all
+    title: 3.3.6 | Ensure secure icmp redirects are not accepted | live ipv4 all
     exec: grep net.ipv4.conf.all.secure_redirects /etc/sysctl.conf /etc/sysctl.d/*.conf /run/sysctl.d/*.conf /usr/local/lib/sysctl.d/*.conf /usr/lib/sysctl.d/*.conf /lib/sysctl.d/*.conf
     exit-status:
       or:
@@ -68,7 +68,7 @@ command:
       - CM-7
       - IA-5
   ipv4_default_secure_redirects:
-    title: 3.3.6 | Ensure secure icmp redirects are not accepted | | live ipv4 default
+    title: 3.3.6 | Ensure secure icmp redirects are not accepted | live ipv4 default
     exec: grep net.ipv4.conf.default.secure_redirects /etc/sysctl.conf /etc/sysctl.d/*.conf /run/sysctl.d/*.conf /usr/local/lib/sysctl.d/*.conf /usr/lib/sysctl.d/*.conf /lib/sysctl.d/*.conf
     exit-status:
       or:

--- a/section_3/cis_3.3/cis_3.3.7.yml
+++ b/section_3/cis_3.3/cis_3.3.7.yml
@@ -43,7 +43,7 @@ kernel-param:
       - IA-5
 command:
   ipv4_all_rp_filter:
-    title: 3.3.7 | Ensure reverse path filtering is enabled | | live ipv4 all
+    title: 3.3.7 | Ensure reverse path filtering is enabled | live ipv4 all
     exec: grep net.ipv4.conf.all.rp_filter /etc/sysctl.conf /etc/sysctl.d/*.conf /run/sysctl.d/*.conf /usr/local/lib/sysctl.d/*.conf /usr/lib/sysctl.d/*.conf /lib/sysctl.d/*.conf
     exit-status:
       or:
@@ -68,7 +68,7 @@ command:
       - CM-7
       - IA-5
   ipv4_default_rp_filter:
-    title: 3.3.7 | Ensure reverse path filtering is enabled | | live ipv4 default
+    title: 3.3.7 | Ensure reverse path filtering is enabled | live ipv4 default
     exec: grep net.ipv4.conf.default.rp_filter /etc/sysctl.conf /etc/sysctl.d/*.conf /run/sysctl.d/*.conf /usr/local/lib/sysctl.d/*.conf /usr/lib/sysctl.d/*.conf /lib/sysctl.d/*.conf
     exit-status:
       or:

--- a/section_5/cis_5.1/cis_5.1.3.yml
+++ b/section_5/cis_5.1/cis_5.1.3.yml
@@ -4,7 +4,7 @@
   {{ if .Vars.deb12cis_rule_5_1_3 }}
 command:
   /etc/ssh/ssh_host_pub_key_user:
-    title: 5.1.3 | Ensure permissions on SSH public host key files are configured | | user
+    title: 5.1.3 | Ensure permissions on SSH public host key files are configured | user
     exec: "userkeys=$(sudo find /etc/ssh/ -name *_key.pub -type f ! -user root ); echo $userkeys"
     exit-status: 0
     stdout: ['!/./']
@@ -22,7 +22,7 @@ command:
       - AC-3
       - MP-2
   /etc/ssh/ssh_host_pub_key_group:
-    title: 5.1.3 | Ensure permissions on SSH public host key files are configured | | group
+    title: 5.1.3 | Ensure permissions on SSH public host key files are configured | group
     exec: "groupkeys=$(sudo find /etc/ssh/ -name *_key.pub -type f ! -group root ); echo $groupkeys"
     exit-status: 0
     stdout: ['!/./']
@@ -40,7 +40,7 @@ command:
       - AC-3
       - MP-2
   /etc/ssh/ssh_host_pub_key_perms:
-    title: 5.1.3 | Ensure permissions on SSH public host key files are configured | | perms
+    title: 5.1.3 | Ensure permissions on SSH public host key files are configured | perms
     exec: "keysperm=$(sudo find /etc/ssh/ -name *_key.pub -type f  -perm /137 ); echo $keyperms"
     exit-status: 0
     stdout: ['!/./']

--- a/section_5/cis_5.1/cis_5.1.4.yml
+++ b/section_5/cis_5.1/cis_5.1.4.yml
@@ -4,7 +4,7 @@
   {{ if .Vars.deb12cis_rule_5_1_4 }}
 command:
   sshd_access_limited:
-    title: 5.1.4 | Ensure sshd access is configured | | config
+    title: 5.1.4 | Ensure sshd access is configured | config
     exec: grep -Ei "^(Allow|Deny)(Users|Groups)" /etc/ssh/sshd_config /etc/ssh/sshd_config.d/*.conf
     exit-status:
       or:

--- a/section_5/cis_5.1/cis_5.1.5.yml
+++ b/section_5/cis_5.1/cis_5.1.5.yml
@@ -4,7 +4,7 @@
   {{ if .Vars.deb12cis_rule_5_1_5 }}
 file:
   ssh_banner:
-    title: 5.1.5 | Ensure sshd Banner is configured | | sshd_default
+    title: 5.1.5 | Ensure sshd Banner is configured | sshd_default
     path: /etc/ssh/sshd_config
     exists: true
     contents:
@@ -28,7 +28,7 @@ file:
       - IA-5
 command:
   ssh_configd_banner:
-    title: 5.1.5 | Ensure sshd Banner is configured | | conf.d banner settings
+    title: 5.1.5 | Ensure sshd Banner is configured | conf.d banner settings
     exec: grep -Eis '^\s*Banner\s+"?none\b'/etc/ssh/sshd_config.d/*.conf
     exit-status:
       or:

--- a/section_5/cis_5.3.3.3/cis_5.3.3.3.3.yml
+++ b/section_5/cis_5.3.3.3/cis_5.3.3.3.3.yml
@@ -2,7 +2,7 @@
   {{ if .Vars.deb12cis_rule_5_3_3_3_2 }}
 file:
   pwhistory_use_authtok:
-    title: 5.3.3.3.2 | Ensure password history is enforced for the root user | | common-password
+    title: 5.3.3.3.2 | Ensure password history is enforced for the root user | common-password
     path: /etc/pam.d/common-password
     exists: true
     contents:
@@ -19,7 +19,7 @@ file:
       NIST800-53R5: IA-5
 command:
   pwhistory_use_authtok_pam_configs:
-    title: 5.3.3.3.2 | Ensure password history is enforced for the root user | | pam_configs
+    title: 5.3.3.3.2 | Ensure password history is enforced for the root user | pam_configs
     exec: for file in `awk '/Password-Type:/{ f = 1;next } /-Type:/{ f = 0 } f {if (/pam_pwhistory\.so/) print FILENAME}' /usr/share/pam-configs/*`; do grep pam_pwhistory $file | grep -v use_authtok; done
     exit-status:
       or:

--- a/section_6/cis_6.1.3.x/cis_6.1.3.7.yml
+++ b/section_6/cis_6.1.3.x/cis_6.1.3.7.yml
@@ -6,7 +6,7 @@
     {{ if not .Vars.deb12cis_remote_log_host }}
 command:
   local_syslog_module:
-    title: 6.1.3.7 | Ensure rsyslog is not configured to receive logs from a remote client | | module
+    title: 6.1.3.7 | Ensure rsyslog is not configured to receive logs from a remote client | module
     exec: grep "imtcp" /etc/rsyslog.conf /etc/rsyslog.d/*.conf | grep -Ev ":#|port="
     exit-status:
       or:
@@ -32,7 +32,7 @@ command:
       - AU-12
       - CM-6
   local_syslog_input:
-    title: 6.1.3.7 | Ensure rsyslog is not configured to receive logs from a remote client | | server/port
+    title: 6.1.3.7 | Ensure rsyslog is not configured to receive logs from a remote client | server/port
     exec: grep -E "imtcp\" port|InputTCPServerRun" /etc/rsyslog.conf /etc/rsyslog.d/*.conf | grep -v ":#"
     exit-status:
       or:

--- a/section_6/cis_6.1.3.x/cis_6.1.3.8.yml
+++ b/section_6/cis_6.1.3.x/cis_6.1.3.8.yml
@@ -5,7 +5,7 @@
   {{ if .Vars.deb12cis_rule_6_1_3_8 }}
 command:
   rsyslog_logrotate:
-    title: 6.1.3.8 | Ensure logrotate is configured | | Manual Check
+    title: 6.1.3.8 | Ensure logrotate is configured | Manual Check
     exec: echo "Manual | please check file rotaton matches site policy - logrotate"
     exit-status: 0
     stdout:

--- a/section_6/cis_6.2.3.x/cis_6.2.3.15.yml
+++ b/section_6/cis_6.2.3.x/cis_6.2.3.15.yml
@@ -4,7 +4,7 @@
   {{ if .Vars.deb12cis_rule_6_2_3_15 }}
 command:
   auditd_chcon_cnf:
-    title: 6.2.3.15 | Ensure successful and unsuccessful attempts to use the chcon command are collected | | config
+    title: 6.2.3.15 | Ensure successful and unsuccessful attempts to use the chcon command are collected | config
     exec: grep chcon /etc/audit/rules.d/*.rules
     exit-status: 0
     stdout:
@@ -23,7 +23,7 @@ command:
       - AU-12
       - SI-5
   auditd_chcon_live:
-    title: 6.2.3.15 | Ensure successful and unsuccessful attempts to use the chcon command are collected | | running
+    title: 6.2.3.15 | Ensure successful and unsuccessful attempts to use the chcon command are collected | running
     exec: auditctl -l | grep chcon
     exit-status: 0
     stdout:

--- a/section_6/cis_6.2.3.x/cis_6.2.3.16.yml
+++ b/section_6/cis_6.2.3.x/cis_6.2.3.16.yml
@@ -4,7 +4,7 @@
   {{ if .Vars.deb12cis_rule_6_2_3_16 }}
 command:
   auditd_setfacl_cnf:
-    title: 6.2.3.16 | Ensure successful and unsuccessful attempts to use the setfacl command are collected | | config
+    title: 6.2.3.16 | Ensure successful and unsuccessful attempts to use the setfacl command are collected | config
     exec: grep setfacl /etc/audit/rules.d/*.rules
     exit-status: 0
     stdout:
@@ -23,7 +23,7 @@ command:
       - AU-12
       - SI-5
   auditd_setfacl_live:
-    title: 6.2.3.16 | Ensure successful and unsuccessful attempts to use the setfacl command are collected | | running
+    title: 6.2.3.16 | Ensure successful and unsuccessful attempts to use the setfacl command are collected | running
     exec: auditctl -l | grep setfacl
     exit-status: 0
     stdout:

--- a/section_6/cis_6.2.3.x/cis_6.2.3.17.yml
+++ b/section_6/cis_6.2.3.x/cis_6.2.3.17.yml
@@ -4,7 +4,7 @@
   {{ if .Vars.deb12cis_rule_6_2_3_17 }}
 command:
   auditd_chacl_cnf:
-    title: 6.2.3.17 | Ensure successful and unsuccessful attempts to use the chacl command are collected | | config
+    title: 6.2.3.17 | Ensure successful and unsuccessful attempts to use the chacl command are collected | config
     exec: grep chacl /etc/audit/rules.d/*.rules
     exit-status: 0
     stdout:
@@ -23,7 +23,7 @@ command:
       - AU-12
       - SI-5
   auditd_chacl_live:
-    title: 6.2.3.17 | Ensure successful and unsuccessful attempts to use the chacl command are collected | | running
+    title: 6.2.3.17 | Ensure successful and unsuccessful attempts to use the chacl command are collected | running
     exec: auditctl -l | grep chacl
     exit-status: 0
     stdout:

--- a/section_6/cis_6.2.3.x/cis_6.2.3.18.yml
+++ b/section_6/cis_6.2.3.x/cis_6.2.3.18.yml
@@ -4,7 +4,7 @@
   {{ if .Vars.deb12cis_rule_6_2_3_18 }}
 command:
   auditd_usermod_cnf:
-    title: 6.2.3.18 | Ensure successful and unsuccessful attempts to use the usermod command are collected | | config
+    title: 6.2.3.18 | Ensure successful and unsuccessful attempts to use the usermod command are collected | config
     exec: grep usermod /etc/audit/rules.d/*.rules
     exit-status: 0
     stdout:
@@ -23,7 +23,7 @@ command:
       - AU-12
       - SI-5
   auditd_usermod_live:
-    title: 6.2.3.18 | Ensure successful and unsuccessful attempts to use the usermod command are collected | | running
+    title: 6.2.3.18 | Ensure successful and unsuccessful attempts to use the usermod command are collected | running
     exec: auditctl -l | grep usermod
     exit-status: 0
     stdout:

--- a/section_6/cis_6.2.3.x/cis_6.2.3.6.yml
+++ b/section_6/cis_6.2.3.x/cis_6.2.3.6.yml
@@ -4,7 +4,7 @@
   {{ if .Vars.deb12cis_rule_6_2_3_6 }}
 command:
   auditd_priv_cmds_cnf:
-    title: 6.2.3.6 | Ensure use of privileged commands are collected | | Manual Check Required
+    title: 6.2.3.6 | Ensure use of privileged commands are collected | Manual Check Required
     exec: echo "Manual - Please investigate privilege commands are collected as per documentation"
     exit-status: 0
     stdout:

--- a/section_6/cis_6.2.3.x/cis_6.2.3.7.yml
+++ b/section_6/cis_6.2.3.x/cis_6.2.3.7.yml
@@ -4,7 +4,7 @@
   {{ if .Vars.deb12cis_rule_6_2_3_7 }}
 command:
   auditd_access_cnf:
-    title: 6.2.3.7 | Ensure unsuccessful file access attempts are collected | | conf check
+    title: 6.2.3.7 | Ensure unsuccessful file access attempts are collected | conf check
     exec: grep access /etc/audit/rules.d/*.rules
     exit-status: 0
     stdout:
@@ -24,7 +24,7 @@ command:
       NIST800-53R5:
       - AU-3
   auditd_access_live:
-    title: 6.2.3.7 | Ensure unsuccessful file access attempts are collected | | running
+    title: 6.2.3.7 | Ensure unsuccessful file access attempts are collected | running
     exec: auditctl -l | grep access
     exit-status: 0
     stdout:


### PR DESCRIPTION
Please ensure that you have understood contributing guide
Ensure all commits are signed-by and gpg signed

**Overall Review of Changes:**
Removes the empty middle section (`| |`) from 56 goss test `title:` fields across 30 files. The artifact was introduced in commit 64d12768 ("Title fixes, typos, linting", 2026-03-16) as a side effect of a bulk title rewrite that inserted an extra `|` separator. Restores the standard goss audit title format: `<CIS_ID> | <description> | <subtest>`.

Before:
`title: 5.1.3 | Ensure permissions on SSH public host key files are configured | | user`

After:
`title: 5.1.3 | Ensure permissions on SSH public host key files are configured | user`

The bug only affected branches descended from `benchmark_1.1.0` (count = 56); `latest` was unaffected (count = 0).

**Issue Fixes:**
N/A (no tracking issue filed; surfaced during review of 2026_MAY_QA)

**Enhancements:**
- 56 goss `title:` fields restored to canonical 3-field format across sections 1, 2, 3, 5, and 6

**How has this been tested?:**
- `grep -rn "| |" section_* --include="*.yml"` returns zero hits post-fix
- Diff is title-only: 30 files, 56 insertions / 56 deletions, no non-title changes
- Sample titles compared against `origin/latest` confirm format alignment